### PR TITLE
Fixed prototype pollution in object_set

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -8,6 +8,9 @@ exports["default"] = void 0;
 var setIn = function setIn(obj, path, value) {
   if (path.length == 0 || typeof path.splice == 'undefined' || typeof path[0] == 'undefined') return value;
   var key = path.splice(0, 1);
+  if(key.includes('__proto__') || key.includes('constructor') || key.includes('prototype')){
+    return obj;
+  }
   if (typeof obj[key] == 'undefined') obj[key] = {};
   obj[key] = setIn(obj[key], path, value);
   return obj;


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40indlekofer%2Fobject_set

### ⚙️ Description *

@indlekofer/object_set is vulnerable to Prototype Pollution.. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `path` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
// poc.js
var objectSet = require("@indlekofer/object_set")
var obj = {}
console.log("Before : " + {}.polluted);
objectSet.default(obj,["__proto__","polluted"],"Yes! Its Polluted");
console.log("After : " + {}.polluted);
```


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.



### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `path` and no breaking changes are introduced. :)
