### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 const setIn = (obj, path, value) => {
   if (path.length == 0 || typeof path.splice == 'undefined' || typeof path[0] == 'undefined') return value;
   let key = path.splice(0, 1);
-  if (typeof obj[key] == 'undefined') obj[key] = {};
+  if (isPrototypePolluted(key) || typeof obj[key] == 'undefined') obj[key] = {};
   obj[key] = setIn(obj[key], path, value);
 
   return obj;
 };
+
+const isPrototypePolluted = (key) => /__proto__|constructor|prototype/.test(key);
 
 export default setIn;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,4 +27,9 @@ describe('object_set', () => {
     let srcObj = set({}, ['b', 'b', 'a'], 'a');
     assert.equal(JSON.stringify(srcObj), JSON.stringify(estObj));
   });
+  it('prototype pollution check', () => {
+    let srcObj = {};
+    set(srcObj, ['__proto__', 'polluted'], true);
+    assert.equal({}.polluted, undefined);
+  });
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`@indlekofer/object_set` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40indlekofer%2Fobject_set

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var objectSet = require("@indlekofer/object_set")
var obj = {}
console.log("Before : " + {}.polluted);
objectSet.default(obj,["__proto__","polluted"],"Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @indlekofer/object_set # Install vulnerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105569221-df0a3400-5d65-11eb-9f88-d0942fdea0b8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
